### PR TITLE
Fixed JavaDoc display bug in firefox.

### DIFF
--- a/javadoc.html
+++ b/javadoc.html
@@ -68,7 +68,7 @@
         <div class=well>
           <div class=row>
             <div class=span12>
-              <iframe src="javadoc/index.html" allowtransparency="true" frameborder="1" scrolling="0" width="96%" height="100%"></iframe>
+              <iframe src="javadoc/index.html" allowtransparency="true" frameborder="1" scrolling="0" width="96%" height="800px"></iframe>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Explicitly defined the height of the iframe containing the JavaDoc. 
